### PR TITLE
home user shuffle concept

### DIFF
--- a/app/assets/stylesheets/styleguide.scss
+++ b/app/assets/stylesheets/styleguide.scss
@@ -44,7 +44,7 @@
 .calendar {
   color: $white;
   font-family: 'Montserrat', sans-serif;
-  font-size: 10.5vw;
+  font-size: 8.75vw;
   font-stretch: normal;
   font-style: normal;
   font-weight: 600;
@@ -52,11 +52,11 @@
   text-align: left;
 
   @media (min-width: $mobile-breakpoint-width) {
-    font-size: 3.5vw;
+    font-size: 2.9vw;
   }
 
   @media (min-width: $max-viewport-width) {
-    font-size: 42px;
+    font-size: 35px;
   }
 }
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -9,6 +9,7 @@ class HomeController < ApplicationController
   FRONTPAGE_USERS_COUNT = 4
   VIDEO_USERS_COUNT = 2
   VIP_USERS_COUNT = 8
+  EVENTS_COUNT = 9
 
   def show
     @contents = [
@@ -23,6 +24,7 @@ class HomeController < ApplicationController
     @events = Event.where('end_at >= ?', Time.zone.now)
                    .where(planned: false)
                    .order(begin_at: :asc)
+                   .limit(EVENTS_COUNT)
   end
 
   def set_users

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,14 @@
 class HomeController < ApplicationController
   before_action :set_events, only: [:show]
-  before_action :set_users, only: [:show]
   before_action :set_video_users, only: [:show]
+  before_action :set_frontpage_users, only: [:show]
+  before_action :set_vip_users, only: [:show]
+  before_action :set_users, only: [:show]
+
+  USERS_COUNT = 10
+  FRONTPAGE_USERS_COUNT = 4
+  VIDEO_USERS_COUNT = 2
+  VIP_USERS_COUNT = 8
 
   def show
     @contents = [
@@ -20,17 +27,33 @@ class HomeController < ApplicationController
 
   def set_users
     @users = User.where(locked: false)
-                 .where(video_url: [nil, ''])
                  .where.not(avatar_file_name: nil)
-                 .limit(25)
-                 .shuffle
+                 .where.not(
+                   id: @video_users.map(&:id) +
+                       @frontpage_users.map(&:id) +
+                       @vip_users.map(&:id)
+                 )
+                 .order(created_at: :desc)
+                 .limit(USERS_COUNT)
   end
 
   def set_video_users
     @video_users = User.where(locked: false)
                        .where.not(video_url: [nil, ''])
                        .where.not(avatar_file_name: nil)
-                       .limit(2)
-                       .shuffle
+                       .sample(VIDEO_USERS_COUNT)
+  end
+
+  def set_frontpage_users
+    @frontpage_users = User.where(locked: false)
+                           .where(frontpage: true)
+                           .where.not(avatar_file_name: nil)
+                           .sample(FRONTPAGE_USERS_COUNT)
+  end
+
+  def set_vip_users
+    @vip_users = User.where(locked: false)
+                     .where(vip: true)
+                     .where.not(avatar_file_name: nil)
   end
 end

--- a/app/views/home/show.slim
+++ b/app/views/home/show.slim
@@ -4,30 +4,30 @@
       span.mobile-intro
         = image_tag('logo-die-offene-gesellschaft-blip.svg')
     .desktop-size1x1.desktop-x1.desktop-y1.mobile-hidden
-      = render 'shared/user/tile', user: @users[0 % @users.count]
+      = render 'shared/user/tile', user: @vip_users[0 % HomeController::VIP_USERS_COUNT]
     .desktop-size1x1.desktop-x2.desktop-y1.mobile-hidden
-      = render 'shared/user/tile', user: @users[1 % @users.count]
+      = render 'shared/user/tile', user: @vip_users[1 % HomeController::VIP_USERS_COUNT]
     .desktop-size1x1.desktop-x3.desktop-y1.size1x1.x1.y4
-      = render 'shared/user/tile', user: @users[2 % @users.count]
+      = render 'shared/user/tile', user: @frontpage_users[0 % HomeController::FRONTPAGE_USERS_COUNT]
     .desktop-size1x1.desktop-x4.desktop-y1.size1x1.x2.y4
       = render 'shared/event/tile', event: @events[0 % @events.count]
     .desktop-size1x1.desktop-x5.desktop-y1.size1x1.x1.y6
-      = render 'shared/user/tile', user: @users[4 % @users.count]
+      = render 'shared/user/tile', user: @frontpage_users[1 % HomeController::FRONTPAGE_USERS_COUNT]
     .desktop-size1x1.desktop-x6.desktop-y1.size1x1.x2.y6
-      = render 'shared/user/tile', user: @users[5 % @users.count]
+      = render 'shared/user/tile', user: @frontpage_users[2 % HomeController::FRONTPAGE_USERS_COUNT]
 
     .desktop-size1x1.desktop-x1.desktop-y2.size1x1.x1.y7
       a.call-to-action href="#{participate_path}"
         span
           = t('home.registration')
     .desktop-size1x1.desktop-x2.desktop-y2.mobile-hidden
-      = render 'shared/user/tile', user: @users[6 % @users.count]
+      = render 'shared/user/tile', user: @vip_users[2 % HomeController::VIP_USERS_COUNT]
     .desktop-size4x2.desktop-x3.desktop-y2.size2x1.x1.y5
       .statement.big-title
         = t('home.statements').first
 
     .desktop-size1x1.desktop-x1.desktop-y3.mobile-hidden
-      = render 'shared/user/tile', user: @users[7 % @users.count]
+      = render 'shared/user/tile', user: @vip_users[3 % HomeController::VIP_USERS_COUNT]
     .desktop-size1x1.desktop-x2.desktop-y3.size1x1.x2.y7
       = render 'shared/event/tile', event: @events[1 % @events.count]
 
@@ -45,27 +45,27 @@
         span.link
           = t('home.article')
     .desktop-size1x1.desktop-x3.desktop-y4.mobile-hidden
-      = render 'shared/user/tile', user: @users[8 % @users.count]
+      = render 'shared/user/tile', user: @vip_users[4 % HomeController::VIP_USERS_COUNT]
     .desktop-size1x1.desktop-x4.desktop-y4.mobile-hidden
-      = render 'shared/user/tile', user: @users[9 % @users.count]
+      = render 'shared/user/tile', user: @vip_users[5 % HomeController::VIP_USERS_COUNT]
     .desktop-size1x1.desktop-x5.desktop-y4.mobile-hidden
-      = render 'shared/user/tile', user: @users[10 % @users.count]
+      = render 'shared/user/tile', user: @vip_users[6 % HomeController::VIP_USERS_COUNT]
     .desktop-size1x1.desktop-x6.desktop-y4.size1x1.x1.y10
       = render 'shared/event/tile', event: @events[2 % @events.count]
 
     .desktop-size1x1.desktop-x3.desktop-y5.mobile-hidden
-      = render 'shared/user/tile', user: @users[11 % @users.count]
+      = render 'shared/user/tile', user: @vip_users[7 % HomeController::VIP_USERS_COUNT]
     .desktop-size1x1.desktop-x4.desktop-y5.size1x1.x2.y13
       = render 'shared/event/tile', event: @events[3 % @events.count]
     .desktop-size2x2.desktop-x5.desktop-y5.size2x2.x1.y11
       = render 'shared/user/tile', user: @video_users[0 % @video_users.count]
 
     .desktop-size1x1.desktop-x1.desktop-y6.mobile-hidden
-      = render 'shared/user/tile', user: @users[12 % @users.count]
+      = render 'shared/user/tile', user: @users[0 % HomeController::USERS_COUNT]
     .desktop-size1x1.desktop-x2.desktop-y6.mobile-hidden
-      = render 'shared/user/tile', user: @users[13 % @users.count]
+      = render 'shared/user/tile', user: @users[1 % HomeController::USERS_COUNT]
     .desktop-size1x1.desktop-x3.desktop-y6.size1x1.x2.y10
-      = render 'shared/user/tile', user: @users[14 % @users.count]
+      = render 'shared/user/tile', user: @frontpage_users[3 % HomeController::FRONTPAGE_USERS_COUNT]
     .desktop-size1x1.desktop-x4.desktop-y6.size1x1.x1.y13
       a.call-to-action href="#{participate_path}"
         span
@@ -76,9 +76,9 @@
     .desktop-size2x2.desktop-x2.desktop-y7.mobile-hidden
       = render 'shared/user/tile', user: @video_users[1 % @video_users.count]
     .desktop-size1x1.desktop-x4.desktop-y7.size1x1.x1.y15
-      = render 'shared/user/tile', user: @users[15 % @users.count]
+      = render 'shared/user/tile', user: @users[2 % HomeController::USERS_COUNT]
     .desktop-size1x1.desktop-x5.desktop-y7.size1x1.x2.y16
-      = render 'shared/user/tile', user: @users[16 % @users.count]
+      = render 'shared/user/tile', user: @users[3 % HomeController::USERS_COUNT]
     .desktop-size1x1.desktop-x6.desktop-y7.size1x1.x2.y15
       = render 'shared/event/tile', event: @events[5 % @events.count]
 
@@ -108,27 +108,27 @@
         span.link
           = t('home.article')
     .desktop-size1x1.desktop-x3.desktop-y9.mobile-hidden
-      = render 'shared/user/tile', user: @users[17 % @users.count]
+      = render 'shared/user/tile', user: @users[4 % HomeController::USERS_COUNT]
     .desktop-size1x1.desktop-x4.desktop-y9.mobile-hidden
-      = render 'shared/user/tile', user: @users[18 % @users.count]
+      = render 'shared/user/tile', user: @users[5 % HomeController::USERS_COUNT]
 
     .desktop-size1x1.desktop-x3.desktop-y10.size1x1.x1.y19
       = render 'shared/event/tile', event: @events[7 % @events.count]
     .desktop-size1x1.desktop-x4.desktop-y10.size1x1.x2.y19
-      = render 'shared/user/tile', user: @users[19 % @users.count]
+      = render 'shared/user/tile', user: @users[6 % HomeController::USERS_COUNT]
 
     .desktop-size4x2.desktop-x1.desktop-y11.size2x1.x1.y21
       .statement.big-title
         = t('home.statements').second
     .desktop-size1x1.desktop-x5.desktop-y11.size1x1.x1.y20
-      = render 'shared/user/tile', user: @users[20 % @users.count]
+      = render 'shared/user/tile', user: @users[7 % HomeController::USERS_COUNT]
     .desktop-size1x1.desktop-x6.desktop-y11.size1x1.x2.y20
       = render 'shared/event/tile', event: @events[8 % @events.count]
 
     .desktop-size1x1.desktop-x5.desktop-y12.mobile-hidden
-      = render 'shared/user/tile', user: @users[21 % @users.count]
+      = render 'shared/user/tile', user: @users[8 % HomeController::USERS_COUNT]
     .desktop-size1x1.desktop-x6.desktop-y12.mobile-hidden
-      = render 'shared/user/tile', user: @users[22 % @users.count]
+      = render 'shared/user/tile', user: @users[9 % HomeController::USERS_COUNT]
   = content_for :modals
   coffee:
     window.modalManager = new window.ModalManager()

--- a/app/views/shared/event/_tile.slim
+++ b/app/views/shared/event/_tile.slim
@@ -1,9 +1,9 @@
 a.event href="#event-id-#{event.id}" data-toggle='modal' data-target="#event-id-#{event.id}"
   .date.calendar
-    = l(event.begin_at, format: :short_date) unless event.planned
+    = l(event.begin_at, format: :short_date_with_weekday) unless event.planned
   .venue
     - venue = event.venue
-    = venue.name
+    = venue.city
 - content_for :modals do
   .modal.fade id="event-id-#{event.id}" tabindex="-1" role="dialog" aria-labelledby="event-id-#{event.id}" aria-hidden="true"
     .modal-dialog role="document"

--- a/app/views/shared/user/_tile.slim
+++ b/app/views/shared/user/_tile.slim
@@ -2,26 +2,27 @@ ruby:
   picture = defined?(picture) && picture == false ? false : true
   statement = defined?(statement) && statement ? true : false
 
-a.user href="#user-id-#{user.id}" style="#{"background-image: url(#{asset_url(user.avatar(:normal))});" unless statement}" data-toggle='modal' data-target="#user-id-#{user.id}"
-  - if statement
-    p.statement.quote
-      = user.statement
-    .name-and-role
-      p.box-details
-        = "#{user.forename} #{user.surname}"
-      p.quote-role
-        = user.role
-  - elsif user.video_user?
-    = image_tag 'video-play.svg',
-                class: 'video-play-icon'
-- content_for :modals do
-  .modal.fade id="user-id-#{user.id}" tabindex="-1" role="dialog" aria-labelledby="user-id-#{user.id}" aria-hidden="true"
-    .modal-dialog role="document"
-      .modal-content
-        button.close type="button" data-dismiss="modal" aria-label="Close"
-          span aria-hidden="true"
-            = fa_icon 'times'
-        .modal-body.user-modal
-            = render 'shared/user/modal_details',
-                     user: user,
-                     large_user_image: false
+- if user
+  a.user href="#user-id-#{user.id}" style="#{"background-image: url(#{asset_url(user.avatar(:normal))});" unless statement}" data-toggle='modal' data-target="#user-id-#{user.id}"
+    - if statement
+      p.statement.quote
+        = user.statement
+      .name-and-role
+        p.box-details
+          = "#{user.forename} #{user.surname}"
+        p.quote-role
+          = user.role
+    - elsif user.video_user?
+      = image_tag 'video-play.svg',
+                  class: 'video-play-icon'
+  - content_for :modals do
+    .modal.fade id="user-id-#{user.id}" tabindex="-1" role="dialog" aria-labelledby="user-id-#{user.id}" aria-hidden="true"
+      .modal-dialog role="document"
+        .modal-content
+          button.close type="button" data-dismiss="modal" aria-label="Close"
+            span aria-hidden="true"
+              = fa_icon 'times'
+          .modal-body.user-modal
+              = render 'shared/user/modal_details',
+                       user: user,
+                       large_user_image: false

--- a/config/locales/date.de.yml
+++ b/config/locales/date.de.yml
@@ -217,6 +217,7 @@ de:
       short: "%d. %B, %H:%M Uhr"
       short_time: "%H:%M Uhr"
       short_date: "%d.%m."
+      short_date_with_weekday: "%a %d.%m."
       short_year_date: "%d.%m.%y"
       normal_date: "%d.%m.%Y"
     pm: nachmittags

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -15,5 +15,15 @@ FactoryGirl.define do
       email 'video-dude@example.com'
       video_url 'https://www.youtube.com/watch?v=cDcBKVKQizg'
     end
+
+    factory :vip_user do
+      email 'very-important-dude@example.com'
+      vip true
+    end
+
+    factory :frontpage_user do
+      email 'frontpage@example.com'
+      frontpage true
+    end
   end
 end

--- a/spec/requests/smoke_test_spec.rb
+++ b/spec/requests/smoke_test_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe "GET routes", type: :request do
                                 planned: false
     @user = @event.user
     @video_user = FactoryGirl.create :video_user
+    @vip_user = FactoryGirl.create :vip_user
+    @frontpage_user = FactoryGirl.create :frontpage_user
     @admin = FactoryGirl.create :admin
     @venue = @event.venue
     @comment = FactoryGirl.create :comment,


### PR DESCRIPTION
**22 user tiles on HOME**
**9 event tiles**
**1 blog tile**
**2 video tiles**

1 big title box
3 fixed participate tiles
1 fixed faciliation tile
1 fixed about-us tile

---

**within small user tiles** _shuffle_
- [x] 4 initiators (with frontpag flag)
- [x] 8 vips (with vip flag)
- [x] 10 new users (recently published)


**within event tiles** _chronologically_
- [x] implement Day before Date (Do 04.10.)
- [x] change venue to city  
*css changes made*


**within big video tiles** _shuffle_
- [x] 2 user with videos (with video and frontpage flag)


**within big blog tile (first on page)** _shuffle_
- [x] shuffle blog-articles or Links to articles (at the moment)
