### PR TITLE
fix unclosable modal

### DIFF
--- a/app/views/shared/event/_modal.slim
+++ b/app/views/shared/event/_modal.slim
@@ -1,4 +1,4 @@
-.modal.fade id="event-id-#{event.id}" tabindex="-1" role="dialog" aria-labelledby="event-id-#{event.id}" aria-hidden="true"
+.modal.fade id="event-id-#{event.id}" tabindex="-1" role="dialog" aria-labelledby="event-id-#{event.id}" aria-hidden="true" data-turbolinks='false'
   .modal-dialog role="document"
     .modal-content
       button.close type="button" data-dismiss="modal" aria-label="Close"

--- a/app/views/shared/event/_tile.slim
+++ b/app/views/shared/event/_tile.slim
@@ -5,7 +5,7 @@ a.event href="#event-id-#{event.id}" data-toggle='modal' data-target="#event-id-
     - venue = event.venue
     = venue.city
 - content_for :modals do
-  .modal.fade id="event-id-#{event.id}" tabindex="-1" role="dialog" aria-labelledby="event-id-#{event.id}" aria-hidden="true"
+  .modal.fade id="event-id-#{event.id}" tabindex="-1" role="dialog" aria-labelledby="event-id-#{event.id}" aria-hidden="true" data-turbolinks='false'
     .modal-dialog role="document"
       .modal-content
         button.close type="button" data-dismiss="modal" aria-label="Close"

--- a/app/views/shared/user/_tile.slim
+++ b/app/views/shared/user/_tile.slim
@@ -16,7 +16,7 @@ ruby:
       = image_tag 'video-play.svg',
                   class: 'video-play-icon'
   - content_for :modals do
-    .modal.fade id="user-id-#{user.id}" tabindex="-1" role="dialog" aria-labelledby="user-id-#{user.id}" aria-hidden="true"
+    .modal.fade id="user-id-#{user.id}" tabindex="-1" role="dialog" aria-labelledby="user-id-#{user.id}" aria-hidden="true" data-turbolinks='false'
       .modal-dialog role="document"
         .modal-content
           button.close type="button" data-dismiss="modal" aria-label="Close"

--- a/app/views/users/_pictureless_modals.slim
+++ b/app/views/users/_pictureless_modals.slim
@@ -1,6 +1,6 @@
 - if users.any?
   - users.each do |user|
-    .modal.fade id="user-id-#{user.id}" tabindex="-1" role="dialog" aria-labelledby="user-id-#{user.id}" aria-hidden="true"
+    .modal.fade id="user-id-#{user.id}" tabindex="-1" role="dialog" aria-labelledby="user-id-#{user.id}" aria-hidden="true" data-turbolinks='false'
       .modal-dialog role="document"
         .modal-content
           button.close type="button" data-dismiss="modal" aria-label="Close"

--- a/app/views/users/_pictures.slim
+++ b/app/views/users/_pictures.slim
@@ -245,7 +245,7 @@ ruby:
 
 - if member_signed_in?
   - content_for :modals do
-    .modal.fade id="user-id-#{current_user.id}" tabindex="-1" role="dialog" aria-labelledby="user-id-#{current_user.id}" aria-hidden="true"
+    .modal.fade id="user-id-#{current_user.id}" tabindex="-1" role="dialog" aria-labelledby="user-id-#{current_user.id}" aria-hidden="true" data-turbolinks='false'
       .modal-dialog role="document"
         .modal-content
           button.close type="button" data-dismiss="modal" aria-label="Close"


### PR DESCRIPTION
open an event/friend from homepage; in overlay click on kommende aktionen; then click on browser back button: it is now impossible to close overlay by clicking on X (mac | chrome)