### PR TITLE
Mailchimp integration broken

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ end
 
 group :development do
   gem 'better_errors'
+  gem 'foreman'
   gem 'letter_opener'
   gem 'listen'
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,8 @@ GEM
     ffi (1.9.14)
     font-awesome-rails (4.6.3.1)
       railties (>= 3.2, < 5.1)
+    foreman (0.82.0)
+      thor (~> 0.19.1)
     gibbon (1.2.1)
       httparty
       multi_json (>= 1.9.0)
@@ -359,6 +361,7 @@ DEPENDENCIES
   factory_girl_rails
   faker
   font-awesome-rails
+  foreman
   gibbon (~> 1.2.0)
   gravatar_image_tag
   jbuilder

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -93,7 +93,13 @@ class UsersController < ApplicationController
 
   def admin_update_params
     new_params = user_params
-    new_params[:terms_of_use] = true if user_params[:locked] == '0' && admin_signed_in?
+    if admin_signed_in?
+      if user_params[:locked] == '0'
+        new_params[:terms_of_use] = true
+      else
+        new_params.delete(:terms_of_use)
+      end
+    end
     new_params
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -130,8 +130,6 @@ class User < ApplicationRecord
   private
 
   def after_confirmation
-    return if locked
-    send_user_welcome_mail if terms_of_use
     sync_to_mailchimp_later if newsletter
   end
 


### PR DESCRIPTION
last mailchimp entry is on 30.11.

new users with 'newsletter' checked don't receive the mailchimp confirmation mail, only the platform confirmation link.